### PR TITLE
fix exception when null value is present in Google Sheets

### DIFF
--- a/CardMaker/Card/Translation/InceptTranslator.cs
+++ b/CardMaker/Card/Translation/InceptTranslator.cs
@@ -137,7 +137,7 @@ namespace CardMaker.Card.Translation
                 }
                 else if (DictionaryColumnNameToIndex.TryGetValue(sKey, out nIndex))
                 {
-                    sDefineValue = (nIndex >= listLine.Count ? String.Empty : listLine[nIndex].Trim());
+                    sDefineValue = (nIndex >= listLine.Count ? String.Empty : (listLine[nIndex] ?? "").Trim());
                 }
                 else
                 {


### PR DESCRIPTION
I was getting an exception message when using Google Sheets - sometimes the blank cells were getting a null value, and the call to Trim() was triggering the exception. This seemed like the simplest way to fix it.