### PR TITLE
Made all float.TryParse calls culture invariant

### DIFF
--- a/CardMaker/Card/FormattedText/Markup/BackgroundImageMarkup.cs
+++ b/CardMaker/Card/FormattedText/Markup/BackgroundImageMarkup.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using CardMaker.Data;
 using CardMaker.XML;
+using System.Globalization;
 
 namespace CardMaker.Card.FormattedText.Markup
 {
@@ -76,8 +77,8 @@ namespace CardMaker.Card.FormattedText.Markup
                         return true;
                     case 5:
                         {
-                            if (float.TryParse(arrayComponents[1], out m_fXOffset) &&
-                                float.TryParse(arrayComponents[2], out m_fYOffset) &&
+                            if (float.TryParse(arrayComponents[1].Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out m_fXOffset) &&
+                                float.TryParse(arrayComponents[2].Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out m_fYOffset) &&
                                 int.TryParse(arrayComponents[3], out m_nWidth) &&
                                 int.TryParse(arrayComponents[4], out m_nHeight))
                             {

--- a/CardMaker/Card/FormattedText/Markup/FontSizeMarkup.cs
+++ b/CardMaker/Card/FormattedText/Markup/FontSizeMarkup.cs
@@ -24,6 +24,7 @@
 
 using System.Drawing;
 using CardMaker.XML;
+using System.Globalization;
 
 namespace CardMaker.Card.FormattedText.Markup
 {
@@ -36,7 +37,7 @@ namespace CardMaker.Card.FormattedText.Markup
         public override bool ProcessMarkup(ProjectLayoutElement zElement, FormattedTextData zData, FormattedTextProcessData zProcessData, Graphics zGraphics)
         {
             float fNewSize;
-            if (float.TryParse(m_sVariable, out fNewSize) && fNewSize > 0)
+            if (float.TryParse(m_sVariable.Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out fNewSize) && fNewSize > 0)
             {
                 m_zPreviousFont = zProcessData.Font;
                 zProcessData.SetFont(new Font(zProcessData.Font.FontFamily, fNewSize, zProcessData.Font.Style), zGraphics);

--- a/CardMaker/Card/FormattedText/Markup/ImageMarkup.cs
+++ b/CardMaker/Card/FormattedText/Markup/ImageMarkup.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using CardMaker.Data;
 using CardMaker.XML;
+using System.Globalization;
 
 namespace CardMaker.Card.FormattedText.Markup
 {
@@ -66,18 +67,18 @@ namespace CardMaker.Card.FormattedText.Markup
                     TargetRect = new RectangleF(zProcessData.CurrentX, zProcessData.CurrentY, zBmp.Width, zBmp.Height);
                     break;
                 case 2:
-                    float.TryParse(arrayComponents[1], out fLineHeightPercent);
+                    float.TryParse(arrayComponents[1].Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out fLineHeightPercent);
                     TargetRect = new RectangleF(zProcessData.CurrentX, zProcessData.CurrentY, zBmp.Width, zBmp.Height);
                     break;
                 case 3:
-                    if (float.TryParse(arrayComponents[1], out m_fXOffset) &&
-                        float.TryParse(arrayComponents[2], out m_fYOffset))
+                    if (float.TryParse(arrayComponents[1].Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out m_fXOffset) &&
+                        float.TryParse(arrayComponents[2].Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out m_fYOffset))
                     {
                         TargetRect = new RectangleF(zProcessData.CurrentX, zProcessData.CurrentY, zBmp.Width, zBmp.Height);
                     }
                     break;
                 case 4:
-                    float.TryParse(arrayComponents[1], out fLineHeightPercent);
+                    float.TryParse(arrayComponents[1].Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out fLineHeightPercent);
                     if (float.TryParse(arrayComponents[2], out m_fXOffset) &&
                         float.TryParse(arrayComponents[3], out m_fYOffset))
                     {
@@ -88,8 +89,8 @@ namespace CardMaker.Card.FormattedText.Markup
                     {
                         int nWidth;
                         int nHeight;
-                        if (float.TryParse(arrayComponents[1], out m_fXOffset) &&
-                            float.TryParse(arrayComponents[2], out m_fYOffset) &&
+                        if (float.TryParse(arrayComponents[1].Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out m_fXOffset) &&
+                            float.TryParse(arrayComponents[2].Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out m_fYOffset) &&
                             int.TryParse(arrayComponents[3], out nWidth) &&
                             int.TryParse(arrayComponents[4], out nHeight))
                         {

--- a/CardMaker/Card/FormattedText/Markup/XDrawOffsetMarkup.cs
+++ b/CardMaker/Card/FormattedText/Markup/XDrawOffsetMarkup.cs
@@ -24,6 +24,7 @@
 
 using System.Drawing;
 using CardMaker.XML;
+using System.Globalization;
 
 namespace CardMaker.Card.FormattedText.Markup
 {
@@ -36,7 +37,7 @@ namespace CardMaker.Card.FormattedText.Markup
         public override bool ProcessMarkup(ProjectLayoutElement zElement, FormattedTextData zData, FormattedTextProcessData zProcessData, Graphics zGraphics)
         {
             float fXOffset;
-            if (float.TryParse(m_sVariable, out fXOffset))
+            if (float.TryParse(m_sVariable.Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out fXOffset))
             {
                 m_fPreviousOffset = zProcessData.CurrentXOffset;
                 zProcessData.CurrentXOffset = fXOffset;

--- a/CardMaker/Card/FormattedText/Markup/YDrawOffsetMarkup.cs
+++ b/CardMaker/Card/FormattedText/Markup/YDrawOffsetMarkup.cs
@@ -24,6 +24,7 @@
 
 using System.Drawing;
 using CardMaker.XML;
+using System.Globalization;
 
 namespace CardMaker.Card.FormattedText.Markup
 {
@@ -36,7 +37,7 @@ namespace CardMaker.Card.FormattedText.Markup
         public override bool ProcessMarkup(ProjectLayoutElement zElement, FormattedTextData zData, FormattedTextProcessData zProcessData, Graphics zGraphics)
         {
             float fYOffset;
-            if (float.TryParse(m_sVariable, out fYOffset))
+            if (float.TryParse(m_sVariable.Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out fYOffset))
             {
                 m_fPreviousOffset = zProcessData.CurrentYOffset;
                 zProcessData.CurrentYOffset = fYOffset;

--- a/CardMaker/Card/Translation/TranslatorBase.cs
+++ b/CardMaker/Card/Translation/TranslatorBase.cs
@@ -28,6 +28,7 @@ using System.Reflection;
 using CardMaker.Card.FormattedText;
 using CardMaker.Data;
 using CardMaker.XML;
+using System.Globalization;
 
 namespace CardMaker.Card.Translation
 {
@@ -134,7 +135,7 @@ namespace CardMaker.Card.Translation
                         else if (zProperty.PropertyType == typeof(float))
                         {
                             float fValue;
-                            if (float.TryParse(sValue, out fValue))
+                            if (float.TryParse(sValue.Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out fValue))
                             {
                                 zMethod.Invoke(zOverrideElement, new object[] { fValue });
                             }

--- a/CardMaker/XML/ProjectLayoutElement.cs
+++ b/CardMaker/XML/ProjectLayoutElement.cs
@@ -29,6 +29,7 @@ using System.Reflection;
 using System.Xml.Serialization;
 using CardMaker.Data;
 using Support.IO;
+using System.Globalization;
 
 namespace CardMaker.XML
 {
@@ -326,7 +327,7 @@ namespace CardMaker.XML
         {
             var arraySplit = fontString.Split(new char[] { ';' });
             float fFontSize;
-            if (6 != arraySplit.Length || !float.TryParse(arraySplit[1], out fFontSize))
+            if (6 != arraySplit.Length || !float.TryParse(arraySplit[1].Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out fFontSize))
             {
                 return null;
             }


### PR DESCRIPTION
The problem was that on some PCs (tested on Croatian region) 0.6 was parsed as as "6" because it was expecting 0,6 with a comma.

Added a "recommended", culture-invariant way to parse float.

nhmkdev/cardmaker#35