### PR TITLE
Update for FilenameTranslator.cs to allow card sub-index naming

### DIFF
--- a/CardMaker/Card/Translation/FilenameTranslator.cs
+++ b/CardMaker/Card/Translation/FilenameTranslator.cs
@@ -97,7 +97,7 @@ namespace CardMaker.Card.Translation
                 }
             }
             // replace ##, #L, Newlines
-            sOutput = sOutput.Replace("##", nCardNumber.ToString(CultureInfo.InvariantCulture).PadLeft(nLeftPad, '0')).Replace("#L", zLayout.Name).Replace(Environment.NewLine, string.Empty);
+            sOutput = sOutput.Replace("##", nCardNumber.ToString(CultureInfo.InvariantCulture).PadLeft(nLeftPad, '0')).Replace("#SI", zCurrentPrintLine.RowSubIndex+1).Replace("#L", zLayout.Name).Replace(Environment.NewLine, string.Empty);
 
             // last chance: replace unsupported characters (for file name)
             var zBuilder = new StringBuilder();


### PR DESCRIPTION
Adding #SI for filenames to allow sub-index numbering (for example Room-#SI with a count of 4 for a card would return Room-1, Room-2, Room-3, and Room-4.  Important when card deck index doesn't matter but multiples of a particular card with different info based on sub index are.