### PR TITLE
Added options for changing how Javascript Translator escapes references

### DIFF
--- a/CardMaker/Card/Translation/JavaScriptTranslator.cs
+++ b/CardMaker/Card/Translation/JavaScriptTranslator.cs
@@ -95,7 +95,7 @@ namespace CardMaker.Card.Translation
 
             for (int nIdx = 0; nIdx < ListColumnNames.Count; nIdx++)
             {
-                AddVar(zBuilder, ListColumnNames[nIdx], zDeckLine.LineColumns[nIdx]);
+                AddVar(zBuilder, ListColumnNames[nIdx], zDeckLine.LineColumns.Count > nIdx ? zDeckLine.LineColumns[nIdx] : "");
             }
             zBuilder.Append(sDefintion);
             return zBuilder.ToString();

--- a/CardMaker/Card/Translation/JavaScriptTranslator.cs
+++ b/CardMaker/Card/Translation/JavaScriptTranslator.cs
@@ -25,6 +25,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using CardMaker.Events.Managers;
 using CardMaker.XML;
 using Microsoft.ClearScript.V8;
 using Support.IO;
@@ -116,22 +117,26 @@ namespace CardMaker.Card.Translation
             zBuilder.Append("=");
             // functions or single quoted items are left as-is
             // note this does not tolerate (whitespace)'
-            if (sValue.StartsWith(FUNCTION_PREFIX))
+            if (sValue.StartsWith(FUNCTION_PREFIX) && ProjectManager.Instance.LoadedProject.jsKeepFunctions)
             {
                 zBuilder.AppendLine(sValue);
             }
-            else if (sValue.StartsWith("'"))
+            else if (sValue.StartsWith("'") && !ProjectManager.Instance.LoadedProject.jsEscapeSingleQuotes)
             {
                 zBuilder.Append(sValue);
                 zBuilder.AppendLine(";");
             }
-            else if (sValue.StartsWith("~"))
+            else if (sValue.StartsWith("~") && ProjectManager.Instance.LoadedProject.jsTildeMeansCode)
             {
                 zBuilder.Append(sValue.Substring(1));
                 zBuilder.AppendLine(";");
             }
             else
             {
+                if (ProjectManager.Instance.LoadedProject.jsEscapeSingleQuotes)
+                {
+                    sValue = sValue.Replace("'", @"\'");
+                }
                 zBuilder.Append("'");
                 zBuilder.Append(sValue);
                 zBuilder.AppendLine("';");

--- a/CardMaker/Forms/Dialogs/ProjectSettingsDialog.cs
+++ b/CardMaker/Forms/Dialogs/ProjectSettingsDialog.cs
@@ -39,12 +39,17 @@ namespace CardMaker.Forms.Dialogs
             const string TRANSLATOR = "translator";
             const string DEFAULT_DEFINE_REFERENCE_TYPE = "default_define_reference_type";
             const string OVERRIDE_DEFINE_REFRENCE_NAME = "override_define_reference_name";
+            const string JS_ESCAPE_SINGLE_QUOTES = "js_escape_single_quotes";
+            const string JS_TILDE_CODE = "js_tilde_code";
+            const string JS_KEEP_FUNCTIONS = "js_keep_functions";
 
-            var zQuery = new QueryPanelDialog("Project Settings", 550, 300, false);
+            var zQuery = new QueryPanelDialog("Project Settings", 550, 300, true);
             zQuery.SetIcon(Resources.CardMakerIcon);
 
             TranslatorType eTranslator = ProjectManager.Instance.LoadedProjectTranslatorType;
             ReferenceType eDefaultDefineReferenceType = ProjectManager.Instance.LoadedProjectDefaultDefineReferenceType;
+
+            zQuery.ChangeToTab("Base");
 
             zQuery.AddPullDownBox("Translator",
                 Enum.GetNames(typeof(TranslatorType)), (int)eTranslator, TRANSLATOR);
@@ -65,12 +70,20 @@ namespace CardMaker.Forms.Dialogs
                 (zGoogleSpreadsheetBrowser, txtOverride) => { txtOverride.Text = zGoogleSpreadsheetBrowser.SelectedSpreadsheet.Title.Text; },
                 OVERRIDE_DEFINE_REFRENCE_NAME);
 
+            zQuery.ChangeToTab("Javascript");
+            zQuery.AddCheckBox("Escape Single Quotes", ProjectManager.Instance.LoadedProject.jsEscapeSingleQuotes, JS_ESCAPE_SINGLE_QUOTES);
+            zQuery.AddCheckBox("~ Means Code", ProjectManager.Instance.LoadedProject.jsTildeMeansCode, JS_TILDE_CODE);
+            zQuery.AddCheckBox("Keep Functions", ProjectManager.Instance.LoadedProject.jsKeepFunctions, JS_KEEP_FUNCTIONS);
+
             if (DialogResult.OK == zQuery.ShowDialog(parentForm))
             {
                 ProjectManager.Instance.LoadedProject.translatorName = ((TranslatorType)zQuery.GetIndex(TRANSLATOR)).ToString();
                 ProjectManager.Instance.LoadedProject.defaultDefineReferenceType = ((ReferenceType)zQuery.GetIndex(DEFAULT_DEFINE_REFERENCE_TYPE)).ToString();
                 ProjectManager.Instance.LoadedProject.overrideDefineReferenceName =
                     zQuery.GetString(OVERRIDE_DEFINE_REFRENCE_NAME).Trim();
+                ProjectManager.Instance.LoadedProject.jsEscapeSingleQuotes = zQuery.GetBool(JS_ESCAPE_SINGLE_QUOTES);
+                ProjectManager.Instance.LoadedProject.jsTildeMeansCode = zQuery.GetBool(JS_TILDE_CODE);
+                ProjectManager.Instance.LoadedProject.jsKeepFunctions = zQuery.GetBool(JS_KEEP_FUNCTIONS);
                 ProjectManager.Instance.FireProjectUpdated(true);
                 LayoutManager.Instance.InitializeActiveLayout();
             }

--- a/CardMaker/Support/UI/QueryPanelDialog.cs
+++ b/CardMaker/Support/UI/QueryPanelDialog.cs
@@ -337,7 +337,10 @@ namespace Support.UI
                 }
                 if (nLargestHeight > 0)
                 {
-                    nLargestHeight = Math.Min(m_nMaxDesiredHeight, nLargestHeight);
+                    if (m_nMaxDesiredHeight > 0)
+                    {
+                        nLargestHeight = Math.Min(m_nMaxDesiredHeight, nLargestHeight);
+                    }
                     // hard coded extra vertical space
                     m_zForm.ClientSize = new Size(m_zForm.ClientSize.Width, nLargestHeight + 60);
                 }

--- a/CardMaker/XML/Project.cs
+++ b/CardMaker/XML/Project.cs
@@ -44,6 +44,12 @@ namespace CardMaker.XML
 
         public string overrideDefineReferenceName { get; set; }
 
+        public bool jsEscapeSingleQuotes { get; set; }
+
+        public bool jsTildeMeansCode { get; set; } = true;
+
+        public bool jsKeepFunctions { get; set; } = true;
+
         #endregion
 
         /// <summary>


### PR DESCRIPTION
Specifically, an option to escape all single quotes and a couple for turning off the "function(" and "~" non-escapes. Motivated initially by wanting to fix the exception if your reference has any apostrophes in it, and then additionally by my desire to have spreadsheets who've no idea they'll be fed into a javascript interpreter.