### PR TITLE
Add double quotes to csv escaping

### DIFF
--- a/CardMaker/Support/IO/CSVFile.cs
+++ b/CardMaker/Support/IO/CSVFile.cs
@@ -84,8 +84,15 @@ namespace Support.IO
                 {
                     switch (sLine[nIdx])
                     {
-                        case '\"':
-                            if (bQuote)
+                        case '"':
+
+                            if (sLine.Length > nIdx + 1 && sLine[nIdx + 1] == '"')
+                            {
+                                // insert csv standard double quotes escapes
+                                nIdx++;
+                                zBuilder.Append("\"");
+                            }
+                            else if (bQuote)
                             {
                                 if (bKeepQuotes)
                                 {


### PR DESCRIPTION
Since .csv files have poor handling on many levels in standard editors, including excel, this proposed fix allows double quotes to be handled closer to standard (by being automatically escaped) 