### PR TITLE
Scale function for layout

### DIFF
--- a/CardMaker/Forms/MDILayoutControl.Designer.cs
+++ b/CardMaker/Forms/MDILayoutControl.Designer.cs
@@ -54,6 +54,7 @@ namespace CardMaker.Forms
         {
             this.components = new System.ComponentModel.Container();
             this.groupBoxCardSet = new System.Windows.Forms.GroupBox();
+            this.btnConfigureSize = new System.Windows.Forms.Button();
             this.checkLoadAllReferences = new System.Windows.Forms.CheckBox();
             this.btnScale = new System.Windows.Forms.Button();
             this.resizeBtn = new System.Windows.Forms.Button();
@@ -87,7 +88,7 @@ namespace CardMaker.Forms
             this.label2 = new System.Windows.Forms.Label();
             this.numericRowIndex = new System.Windows.Forms.NumericUpDown();
             this.label1 = new System.Windows.Forms.Label();
-            this.btnConfigureSize = new System.Windows.Forms.Button();
+            this.btnScaleDpi = new System.Windows.Forms.Button();
             this.groupBoxCardSet.SuspendLayout();
             this.contextMenuElements.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericCardSetDPI)).BeginInit();
@@ -101,6 +102,7 @@ namespace CardMaker.Forms
             // 
             // groupBoxCardSet
             // 
+            this.groupBoxCardSet.Controls.Add(this.btnScaleDpi);
             this.groupBoxCardSet.Controls.Add(this.btnConfigureSize);
             this.groupBoxCardSet.Controls.Add(this.checkLoadAllReferences);
             this.groupBoxCardSet.Controls.Add(this.btnScale);
@@ -129,6 +131,16 @@ namespace CardMaker.Forms
             this.groupBoxCardSet.TabIndex = 12;
             this.groupBoxCardSet.TabStop = false;
             this.groupBoxCardSet.Text = "Card Layout";
+            // 
+            // btnConfigureSize
+            // 
+            this.btnConfigureSize.Location = new System.Drawing.Point(257, 41);
+            this.btnConfigureSize.Name = "btnConfigureSize";
+            this.btnConfigureSize.Size = new System.Drawing.Size(59, 20);
+            this.btnConfigureSize.TabIndex = 34;
+            this.btnConfigureSize.Text = "Setup";
+            this.btnConfigureSize.UseVisualStyleBackColor = true;
+            this.btnConfigureSize.Click += new System.EventHandler(this.btnConfigureSize_Click);
             // 
             // checkLoadAllReferences
             // 
@@ -212,27 +224,27 @@ namespace CardMaker.Forms
             this.pasteSettingsToolStripMenuItem});
             this.contextMenuElements.Name = "contextMenuElements";
             this.contextMenuElements.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.contextMenuElements.Size = new System.Drawing.Size(156, 70);
+            this.contextMenuElements.Size = new System.Drawing.Size(157, 70);
             this.contextMenuElements.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuElements_Opening);
             // 
             // copyToolStripMenuItem
             // 
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
             this.copyToolStripMenuItem.Text = "Copy";
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
             // 
             // pasteToolStripMenuItem
             // 
             this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
-            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
             this.pasteToolStripMenuItem.Text = "Paste";
             this.pasteToolStripMenuItem.Click += new System.EventHandler(this.pasteToolStripMenuItem_Click);
             // 
             // pasteSettingsToolStripMenuItem
             // 
             this.pasteSettingsToolStripMenuItem.Name = "pasteSettingsToolStripMenuItem";
-            this.pasteSettingsToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.pasteSettingsToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
             this.pasteSettingsToolStripMenuItem.Text = "Paste Settings...";
             this.pasteSettingsToolStripMenuItem.Click += new System.EventHandler(this.pasteSettingsToolStripMenuItem_Click);
             // 
@@ -511,15 +523,15 @@ namespace CardMaker.Forms
             this.label1.Text = "Card:";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // btnConfigureSize
+            // btnScaleDpi
             // 
-            this.btnConfigureSize.Location = new System.Drawing.Point(257, 41);
-            this.btnConfigureSize.Name = "btnConfigureSize";
-            this.btnConfigureSize.Size = new System.Drawing.Size(59, 20);
-            this.btnConfigureSize.TabIndex = 34;
-            this.btnConfigureSize.Text = "Setup";
-            this.btnConfigureSize.UseVisualStyleBackColor = true;
-            this.btnConfigureSize.Click += new System.EventHandler(this.btnConfigureSize_Click);
+            this.btnScaleDpi.Location = new System.Drawing.Point(257, 16);
+            this.btnScaleDpi.Name = "btnScaleDpi";
+            this.btnScaleDpi.Size = new System.Drawing.Size(59, 20);
+            this.btnScaleDpi.TabIndex = 35;
+            this.btnScaleDpi.Text = "Scale";
+            this.btnScaleDpi.UseVisualStyleBackColor = true;
+            this.btnScaleDpi.Click += new System.EventHandler(this.btnScaleDpi_Click);
             // 
             // MDILayoutControl
             // 
@@ -583,5 +595,6 @@ namespace CardMaker.Forms
         private System.Windows.Forms.CheckBox checkLoadAllReferences;
         private System.Windows.Forms.ToolStripMenuItem pasteSettingsToolStripMenuItem;
         private System.Windows.Forms.Button btnConfigureSize;
+        private System.Windows.Forms.Button btnScaleDpi;
     }
 }

--- a/CardMaker/Forms/MDILayoutControl.cs
+++ b/CardMaker/Forms/MDILayoutControl.cs
@@ -514,6 +514,35 @@ namespace CardMaker.Forms
             }
         }
 
+        private void btnScaleDpi_Click(object sender, EventArgs e)
+        {
+            const string CARD_DPI = "cardDpi";
+            const string SCALE_BORDER = "scaleBorder";
+            var zQuery = new QueryPanelDialog("CardMaker DPI Converter", 450, 250, false);
+            zQuery.SetIcon(CardMakerInstance.ApplicationIcon);
+            zQuery.SetMaxHeight(600);
+            var oldDpi = numericCardSetDPI.Value;
+            zQuery.AddNumericBox("New DPI", oldDpi, 0, int.MaxValue, 1, 2, CARD_DPI);
+            zQuery.AddCheckBox("Scale layout size", true, SCALE_BORDER);
+            if (DialogResult.OK == zQuery.ShowDialog(this))
+            {
+                var dpiRatio = zQuery.GetDecimal(CARD_DPI) / oldDpi;
+                var scaleLayout = zQuery.GetBool(SCALE_BORDER);
+                numericCardSetDPI.Value = zQuery.GetDecimal(CARD_DPI);
+                if (scaleLayout)
+                {
+                    numericCardSetWidth.Value = (int) Math.Max(1, numericCardSetWidth.Value * dpiRatio);
+                    numericCardSetHeight.Value = (int) Math.Max(1, numericCardSetHeight.Value * dpiRatio);
+                }
+
+                if (LayoutManager.Instance.ActiveLayout.Element != null)
+                {
+                    ElementManager.Instance.ProcessElementsChange(LayoutManager.Instance.ActiveLayout.Element, 0, 0, 0,
+                        0, dpiRatio, dpiRatio, true);
+                }
+            }
+        }
+
         private void btnConfigureSize_Click(object sender, EventArgs e)
         {
             const string CARD_WIDTH = "cardWidth";


### PR DESCRIPTION
Added a simple layout scale function, which I needed on several occasions, usually when changing my mind about the print quality.
Usage: press "Scale" on the layout options, enter the new DPI, check if you want the layout dimensions to scale also (in some corner cases you might not want to) and all the elements do a simple rescale and reposition, as if a "zoom" was performed.