### PR TITLE
Add zoom level per-layout

### DIFF
--- a/CardMaker/Events/Managers/LayoutManager.cs
+++ b/CardMaker/Events/Managers/LayoutManager.cs
@@ -169,10 +169,7 @@ namespace CardMaker.Events.Managers
                 ActiveDeck.SetAndLoadLayout(ActiveLayout, false);
             }
 
-            if (null != LayoutLoaded)
-            {
-                LayoutLoaded(this, new LayoutEventArgs(ActiveLayout, ActiveDeck));
-            }            
+            LayoutLoaded?.Invoke(this, new LayoutEventArgs(ActiveLayout, ActiveDeck));
         }
 
         /// <summary>

--- a/CardMaker/Forms/MDICanvas.cs
+++ b/CardMaker/Forms/MDICanvas.cs
@@ -273,6 +273,15 @@ namespace CardMaker.Forms
         {
             // pass the loaded deck into the renderer
             m_zCardCanvas.Reset(args.Deck);
+            if (args.Deck?.CardLayout.lastZoom != null)
+            {
+                numericUpDownZoom.Value = (decimal) args.Deck.CardLayout.lastZoom;
+            }
+            else
+            {
+                numericUpDownZoom.Value = (decimal) 1.0;
+            }
+
             Redraw();
         }
 
@@ -685,6 +694,7 @@ namespace CardMaker.Forms
             m_fZoom = (float)numericUpDownZoom.Value;
             m_fZoomRatio = 1.0f / m_fZoom;
             TranslationLockState = TranslationLock.Unset;
+            m_zCardCanvas.CardRenderer.CurrentDeck.CardLayout.lastZoom = m_fZoom;
             m_zCardCanvas.CardRenderer.ZoomLevel = m_fZoom;
             LayoutManager.Instance.ActiveDeck.ResetDeckCache();
             m_zCardCanvas.UpdateSize();

--- a/CardMaker/Forms/MDIProject.cs
+++ b/CardMaker/Forms/MDIProject.cs
@@ -188,7 +188,7 @@ namespace CardMaker.Forms
             zQuery.AddTextBox("Name", "New Layout", false, NAME);
             zQuery.AddNumericBox("Width", 300, 1, Int32.MaxValue, WIDTH);
             zQuery.AddNumericBox("Height", 300, 1, Int32.MaxValue, HEIGHT);
-            zQuery.AddNumericBox("DPI", 300, 100, 9600, DPI);
+            zQuery.AddNumericBox("DPI", 300, 100, 600, DPI);
             if (DialogResult.OK == zQuery.ShowDialog(this))
             {
                 var zLayout = new ProjectLayout(zQuery.GetString(NAME))

--- a/CardMaker/XML/ProjectLayout.cs
+++ b/CardMaker/XML/ProjectLayout.cs
@@ -23,6 +23,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 using System.Collections.Generic;
+using System.Runtime.Remoting.Proxies;
+using System.Windows.Forms;
 using System.Xml.Serialization;
 
 namespace CardMaker.XML
@@ -50,6 +52,8 @@ namespace CardMaker.XML
         public int exportWidth { get; set; }
         
         public int exportHeight { get; set; }
+
+        public float? lastZoom { get; set; }
 
         [XmlAttribute]
         public bool combineReferences { get; set; }
@@ -89,6 +93,7 @@ namespace CardMaker.XML
             defaultCount = 1;
             dpi = 100;
             drawBorder = true;
+            lastZoom = 1.0f;
         }
 
         /// <summary>


### PR DESCRIPTION
I often need to click the "fit" button when working and switching between tiles, boards, and cards, so I added the zoom level to project state, per-layout. That way I can continue working more seamlessly between sessions.
This maybe a bit opinionated a change, but I think view state is something that is okay to keep in the save file for tools which work primarily as visual editors.