### PR TITLE
Catch and log errors when adding code values to javascript translator

### DIFF
--- a/CardMaker/Card/Translation/JavaScriptTranslator.cs
+++ b/CardMaker/Card/Translation/JavaScriptTranslator.cs
@@ -148,7 +148,14 @@ namespace CardMaker.Card.Translation
 
         private void AddCode(ScriptEngine zEngine, string sName, string sValue)
         {
-            zEngine.Execute($"{sName.Replace(" ", "_")} = {sValue}");
+            try
+            {
+                zEngine.Execute($"{sName.Replace(" ", "_")} = {sValue}");
+            }
+            catch (ScriptEngineException e)
+            {
+                Logger.AddLogLine(e.ErrorDetails);
+            }
         }
     }
 }


### PR DESCRIPTION
Used `ScriptEngineException` instead of `Exception`, which may be worth doing above as well to get more detailed error messages, and because catching `Exception` is generally bad practice. But I felt that was outside the scope of this PR.